### PR TITLE
Update copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Zach Eriksen
+Copyright (c) 2026 Zach Eriksen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update copyright year from 2025 to 2026 in LICENSE file

## Test plan
- [x] Verified LICENSE file contains updated copyright year

🤖 Generated with [Claude Code](https://claude.com/claude-code)