### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,18 +2,29 @@ name: Documentation
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/docs.yml
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
+# Allow one concurrent deployment; do not cancel an in-progress Pages deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     - name: Build Documentation
@@ -32,6 +43,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -2,13 +2,32 @@ name: macOS
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/macOS.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/macOS.yml
+
+concurrency:
+  group: macOS-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macOS:
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,14 +2,33 @@ name: ubuntu
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ubuntu.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ubuntu.yml
+
+concurrency:
+  group: ubuntu-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
     container: swift:6.0
+    timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
## Summary
- **macOS.yml** (CI): scoped `push`/added `pull_request` to `main` with a swift-spm `paths:` filter (`Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`, `.github/workflows/macOS.yml`); added a `concurrency` group with `cancel-in-progress: true`. Runner stays `macos-latest` (correct for a PUBLIC repo). Bumped `actions/checkout@v5`, added `timeout-minutes`.
- **ubuntu.yml** (CI, Linux Swift build via `swift:6.0` container): same path filter + `pull_request` trigger + concurrency. Runner stays `ubuntu-latest` (deliberate Linux compile, correct for PUBLIC). checkout@v5 + timeout.
- **docs.yml** (Pages): added site-source-scoped `paths:` (`Sources/**`, `Package.swift`, `Package.resolved`, this workflow), added the standard Pages `concurrency` group (`group: pages`, `cancel-in-progress: false` so in-flight deploys are not cancelled). checkout@v5 + `timeout-minutes` on both jobs. Runners unchanged (correct per visibility).

Now a README/docs/LICENSE-only change matches no CI path set and triggers nothing.

Mirrors the CorvidLabs/merlin CI standard.